### PR TITLE
Get fonts from `assets.guim`

### DIFF
--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,10 +1,10 @@
 @font-face {
   font-family: "GT Guardian Titlepiece";
-  src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2")
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff2")
       format("woff2"),
-    url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff")
+    url("https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.woff")
       format("woff"),
-    url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf")
+    url("https://assets.guim.co.uk/static/frontend/fonts/guardian-titlepiece/noalts-not-hinted/GTGuardianTitlepiece-Bold.ttf")
       format("truetype");
   font-weight: 700;
   font-style: normal;
@@ -12,11 +12,11 @@
 
 @font-face {
   font-family: "GH Guardian Headline";
-  src: url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff2")
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff2")
       format("woff2"),
-    url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.woff")
+    url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.woff")
       format("woff"),
-    url("https://pasteup.guim.co.uk/webfonts/1.0.0/noalts-not-hinted/GHGuardianHeadline-Bold.ttf")
+    url("https://assets.guim.co.uk/static/frontend/fonts/guardian-headline/noalts-not-hinted/GHGuardianHeadline-Bold.ttf")
       format("truetype");
   font-weight: 700;
   font-style: normal;
@@ -24,11 +24,11 @@
 
 @font-face {
   font-family: "GuardianTextEgyptian";
-  src: url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff2")
+  src: url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff2")
       format("woff2"),
-    url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.woff")
+    url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.woff")
       format("woff"),
-    url("https://interactive.guim.co.uk/fonts/sep2018/noalts_not_hinted_webmetrics/textegyptian/GuardianTextEgyptian-Regular.ttf")
+    url("https://assets.guim.co.uk/static/frontend/fonts/guardian-textegyptian/noalts-not-hinted/GuardianTextEgyptian-Regular.ttf")
       format("truetype");
   font-weight: 400;
   font-style: normal;


### PR DESCRIPTION
## What does this change?

This PR updates the source values in the `@font-face` tags to fetch fonts from the `assets.guim` domain.

## How to test

Run the application and observe that the text content is still rendered with the correct typeface.

## How can we measure success?

Fonts are loaded from the correct location